### PR TITLE
Feat: API v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 
 # explo notebooks
 notebooks/EXPLO_*
+dataset*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,131 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# explo notebooks
+notebooks/EXPLO_*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8-slim
+
+RUN apt-get update -y
+RUN apt-get install curl -y
+RUN curl -LJS https://github.com/ambanum/CGUs-versions/releases/download/2020-11-23-16e3f34/dataset-2020-11-23-16e3f34.zip -o dataset.zip
+
+RUN apt-get install unzip -y
+RUN unzip dataset.zip && mv dataset-2020-11-23-16e3f34 dataset
+
+COPY ./app /app

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The API is served at `localhost`.
 
 This API was built using `python3.8`. We suggest you use a virtual environment.
 
+You will also need a local copy of the dataset. By default, it is assumed to be in `./app/dataset` but you can always change this by editing `./app/config.py`.
+
 Install requirements
 
 ```sh
@@ -36,5 +38,3 @@ cd app
 export PYTHONPATH=.
 uvicorn main:app --reload
 ```
-
-Note: you might need to edit `config.py` to give it the path to your local copy of the dataset.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # CGUs-api
+
+## Get Started
+
+### Running with Docker
+
+The easiest option if you have Docker installed as it will automatically download the data for you.
+
+```sh
+docker build --no-cache --tag cgus-api:latest .
+docker run -d --name myapi -p 80:80 cgus-api:latest
+```
+
+The API is served at `localhost`.
+
+### Running with python (for development)
+
+This API was built using `python3.8`. We suggest you use a virtual environment.
+
+Install requirements
+
+```sh
+python -m pip install -r requirements.txt
+```
+
+Navigate to the `./app` directory and run the app
+
+```
+cd app
+export PYTHONPATH=.
+uvicorn main:app --reload
+```
+
+Note: you might need to edit `config.py` to give it the path to your local copy of the dataset.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ## Get Started
 
+### Endpoints
+
+So far the API has two endpoints:
+- `/first_occurence/v1/{term}` returns the first occurence of a given term for each "service" / "document_type" pair
+- `/` and `/docs` is automatically generated documentation
+
 ### Running with Docker
 
 The easiest option if you have Docker installed as it will automatically download the data for you.

--- a/app/config.py
+++ b/app/config.py
@@ -1,1 +1,2 @@
-CGUS_DATASET_PATH = "../../CGUs/cgus-dataset/"
+CGUS_DATASET_PATH = "./dataset/"
+DATASET_DATE_FORMAT = "%Y-%m-%d--%H-%M-%S"

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,1 @@
+CGUS_DATASET_PATH = "../../CGUs/cgus-dataset/"

--- a/app/dataset_parser.py
+++ b/app/dataset_parser.py
@@ -1,0 +1,96 @@
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path, PosixPath
+import re
+
+class CGUsDataset():
+    """
+    Helper class for handling CGUs Versions
+    """
+
+    def __init__(self, root_path: str = "../CGUs-versions"):
+        self.root_path = Path(root_path)
+        assert self.root_path.exists(), f"{root_path} does not exist"
+        assert self.root_path.is_dir(), f"{root_path} is not a directory"
+
+
+    def yield_all_md(self, ignore_rootdir: bool = True) -> list:
+        if ignore_rootdir:
+            return self.root_path.glob('**/*/*.md')
+        else:
+            return self.root_path.glob('**/*.md')
+
+
+class CGUsParser(ABC):
+    """
+        Abstract base class for parsing a CGU dataset
+    """
+    def __init__(self, path: PosixPath):
+        self.path = path
+        self.dataset = CGUsDataset(self.path)
+    
+    @abstractmethod
+    def run(self):
+        pass
+
+    @abstractmethod
+    def to_dict(self):
+        pass
+    
+    @staticmethod
+    def _parse_name(file_path):
+        """
+            Given a file path in the CGUs dataset,
+            return the service, the document_type, and the version date
+        """
+        version_date = datetime.fromisoformat(file_path.name.removesuffix(".md"))
+        service, document_type = file_path.as_posix().split("/")[-3:-1]
+        return service, document_type, version_date
+
+
+
+class CGUsFirstOccurenceParser(CGUsParser):
+
+    def __init__(self, path, term):
+        super().__init__(path)
+        self.regex_term = re.compile(rf"{term}")
+    
+    def run(self):
+        """
+            For each service provider, and for each document type,
+            return date of first occurence of a given term, or `False`
+        """
+        self.output = defaultdict(lambda val: val)
+
+        for md in self.dataset.yield_all_md(ignore_rootdir=True):
+            service, document_type, version_date = self._parse_name(md)
+            print(f"Handling {service} {document_type} {version_date}")
+            
+            # TODO: clean and optimize this
+            if service not in self.output.keys():
+                self.output[service] = {document_type: False}
+
+            if document_type not in self.output[service].keys():
+                self.output[service] |= {document_type: False}
+
+            if self._file_contains(md):
+                if not self.output[service][document_type]:
+                    self.output[service][document_type] = version_date
+                elif version_date < self.output[service][document_type]:
+                    self.output[service][document_type] = version_date
+
+
+    def to_dict(self):
+        return self.output
+
+    def _file_contains(self, file_path: Path):
+        with open(file_path, "r") as f:
+            for line in f:
+                if self.regex_term.search(line):
+                    return True
+        return False
+
+
+
+

--- a/app/dataset_parser.py
+++ b/app/dataset_parser.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from collections import defaultdict
 from datetime import datetime
 from pathlib import Path, PosixPath
 import re
@@ -54,20 +53,19 @@ class CGUsParser(ABC):
 
 class CGUsFirstOccurenceParser(CGUsParser):
 
-    def __init__(self, path, term):
+    def __init__(self, path, terms):
         super().__init__(path)
-        self.regex_term = re.compile(rf"{term}", re.IGNORECASE)
+        self.regex_term = re.compile(rf"{self._to_regex(terms)}", re.IGNORECASE)
     
     def run(self):
         """
             For each service provider, and for each document type,
-            return date of first occurence of a given term, or `False`
+            return date of first occurence of a given term (or comma-separated terms), or `False`
         """
-        self.output = defaultdict(lambda val: val)
+        self.output = dict()
 
         for md in self.dataset.yield_all_md(ignore_rootdir=True):
             service, document_type, version_date = self._parse_name(md)
-            print(f"Handling {service} {document_type} {version_date}")
             
             # TODO: clean and optimize this
             if service not in self.output.keys():
@@ -92,6 +90,16 @@ class CGUsFirstOccurenceParser(CGUsParser):
                 if self.regex_term.search(line):
                     return True
         return False
+
+    @staticmethod
+    def _to_regex(comma_separated_terms: str):
+        """
+            Given a string of comma-separated terms,
+            returns a Regex matching any of these terms.
+            "hello,world,California Act" --> "hello|world|California Act"
+        """
+        return comma_separated_terms.replace(",", "|")
+
 
 
 

--- a/app/dataset_parser.py
+++ b/app/dataset_parser.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from pathlib import Path, PosixPath
 import re
 
+from config import DATASET_DATE_FORMAT
+
 class CGUsDataset():
     """
     Helper class for handling CGUs Versions
@@ -44,7 +46,7 @@ class CGUsParser(ABC):
             Given a file path in the CGUs dataset,
             return the service, the document_type, and the version date
         """
-        version_date = datetime.fromisoformat(file_path.name.rstrip(".md"))
+        version_date = datetime.strptime(file_path.name.rstrip(".md"), DATASET_DATE_FORMAT)
         service, document_type = file_path.as_posix().split("/")[-3:-1]
         return service, document_type, version_date
 

--- a/app/dataset_parser.py
+++ b/app/dataset_parser.py
@@ -56,7 +56,7 @@ class CGUsFirstOccurenceParser(CGUsParser):
 
     def __init__(self, path, term):
         super().__init__(path)
-        self.regex_term = re.compile(rf"{term}")
+        self.regex_term = re.compile(rf"{term}", re.IGNORECASE)
     
     def run(self):
         """

--- a/app/dataset_parser.py
+++ b/app/dataset_parser.py
@@ -44,7 +44,7 @@ class CGUsParser(ABC):
             Given a file path in the CGUs dataset,
             return the service, the document_type, and the version date
         """
-        version_date = datetime.fromisoformat(file_path.name.removesuffix(".md"))
+        version_date = datetime.fromisoformat(file_path.name.rstrip(".md"))
         service, document_type = file_path.as_posix().split("/")[-3:-1]
         return service, document_type, version_date
 
@@ -72,7 +72,7 @@ class CGUsFirstOccurenceParser(CGUsParser):
                 self.output[service] = {document_type: False}
 
             if document_type not in self.output[service].keys():
-                self.output[service] |= {document_type: False}
+                self.output[service] = {**self.output[service], **{document_type: False}}
 
             if self._file_contains(md):
                 if not self.output[service][document_type]:

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
+
+from config import CGUS_DATASET_PATH
+from dataset_parser import CGUsFirstOccurenceParser
+
+app = FastAPI()
+
+@app.get("/")
+async def index():
+    return RedirectResponse("/docs")
+
+@app.get("/first_occurence/v1/{term}")
+async def first_occurence(term: str):
+    parser = CGUsFirstOccurenceParser(Path(CGUS_DATASET_PATH), term)
+    parser.run()
+    return parser.to_dict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+click==7.1.2
+fastapi==0.61.2
+h11==0.11.0
+pydantic==1.7.2
+starlette==0.13.6
+uvicorn==0.12.3

--- a/tests/test_dataset/FAKE_README.md
+++ b/tests/test_dataset/FAKE_README.md
@@ -1,0 +1,1 @@
+This README file is here to test the `ignore_rootdir` functionality of the file parser.

--- a/tests/test_dataset/FakeService/Community Guidelines/2020-11-09--17-30-22.md
+++ b/tests/test_dataset/FakeService/Community Guidelines/2020-11-09--17-30-22.md
@@ -1,0 +1,14 @@
+Community Guidelines Faked for Testing Purposes.
+--------------------
+
+_**Blob:** Blip blap blup. Blip blop. Blap._
+
+### One Two
+
+One Two Three Four Five
+
+California Act
+
+### A link
+
+[A link](https://www.google.com/teapot)

--- a/tests/test_dataset/FakeService/Community Guidelines/2020-11-11--16-30-22.md
+++ b/tests/test_dataset/FakeService/Community Guidelines/2020-11-11--16-30-22.md
@@ -1,0 +1,14 @@
+Community Guidelines Faked for Testing Purposes.
+--------------------
+
+_**Blob:** Blip blap blup. Blip blop. Blap._
+
+### One Two
+
+One Two Three Four Five
+
+California Act and RGPD
+
+### A link
+
+[A link](https://www.google.com/teapot)

--- a/tests/unit/test_dataset_parser.py
+++ b/tests/unit/test_dataset_parser.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+sys.path.append("./app/")
+
+import pytest
+
+from app.dataset_parser import CGUsDataset, CGUsFirstOccurenceParser
+
+# test CGUsDataset
+def test_path_check_ok():
+    cgudataset = CGUsDataset(root_path="tests/test_dataset/")
+    assert cgudataset
+
+def test_path_check_not_a_directory():
+    with pytest.raises(AssertionError, match = "is not a directory"):
+        cgudataset = CGUsDataset(root_path="tests/test_dataset/FakeService/Community Guidelines/2020-11-09--17-30-22.md")
+
+def test_path_check_directory_doesnt_exist():
+    with pytest.raises(AssertionError, match = "does not exist"):
+        cgudataset = CGUsDataset(root_path="tests/wrong_dir/")
+
+def test_list_files():
+    cgudataset = CGUsDataset(root_path="tests/test_dataset/")
+    assert len(list(cgudataset.yield_all_md())) == 2
+    assert len(list(cgudataset.yield_all_md(ignore_rootdir=False))) == 3
+
+# test CGUsFirstOccurenceParser
+def test_run_california():
+    parser = CGUsFirstOccurenceParser(Path("tests/test_dataset"), "California")
+    parser.run()
+    output = parser.to_dict()
+    assert set(output.keys()) == {"FakeService"}
+    assert set(output["FakeService"].keys()) == {"Community Guidelines"}
+    assert output["FakeService"]["Community Guidelines"] == datetime(2020, 11, 9, 17, 30, 22)
+
+def test_run_rgpd():
+    parser = CGUsFirstOccurenceParser(Path("tests/test_dataset"), "rgpd")
+    parser.run()
+    output = parser.to_dict()
+    assert output["FakeService"]["Community Guidelines"] == datetime(2020, 11, 11, 16, 30, 22)
+
+def test_run_not_found():
+    parser = CGUsFirstOccurenceParser(Path("tests/test_dataset"), "Ambanum")
+    parser.run()
+    output = parser.to_dict()
+    assert output["FakeService"]["Community Guidelines"] == False


### PR DESCRIPTION
Voilà une première version fonctionnelle et dockerisée de l'API de recherche de termes à travers le temps.

Elle est documentée automatiquement dans sa route `/docs`

Reste à faire:
- tests ! (au moins qques uns)
- support d'une liste de termes plutot qu'un seul ?
- optimisations ? (pour le moment, les perfs sont plus que raisonnables je trouve donc peut etre pas prio)
- intégration au site disinfo
- l'image Docker est basique et pourrait etre améliorée