### PR TITLE
feat: implement rate limiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8-slim
 
+COPY ./requirements.txt /requirements.txt
+RUN pip install -r /requirements.txt
 RUN apt-get update -y
 RUN apt-get install curl -y
 RUN curl -LJS https://github.com/ambanum/CGUs-versions/releases/download/2020-11-23-16e3f34/dataset-2020-11-23-16e3f34.zip -o dataset.zip

--- a/app/config.py
+++ b/app/config.py
@@ -1,2 +1,3 @@
 CGUS_DATASET_PATH = "./dataset/"
 DATASET_DATE_FORMAT = "%Y-%m-%d--%H-%M-%S"
+RATE_LIMIT = "15/minute"

--- a/app/main.py
+++ b/app/main.py
@@ -1,19 +1,28 @@
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
 
-from config import CGUS_DATASET_PATH
+from config import CGUS_DATASET_PATH, RATE_LIMIT
 from dataset_parser import CGUsFirstOccurenceParser
 
+limiter = Limiter(key_func=get_remote_address)
 app = FastAPI()
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
 
 @app.get("/")
-async def index():
+@limiter.limit(RATE_LIMIT)
+async def index(request: Request):
     return RedirectResponse("/docs")
 
 @app.get("/first_occurence/v1/{term}")
-async def first_occurence(term: str):
+@limiter.limit(RATE_LIMIT)
+async def first_occurence(request: Request, term: str):
     parser = CGUsFirstOccurenceParser(Path(CGUS_DATASET_PATH), term)
     parser.run()
     return parser.to_dict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ click==7.1.2
 fastapi==0.61.2
 h11==0.11.0
 pydantic==1.7.2
+slowapi==0.1.2
 starlette==0.13.6
 uvicorn==0.12.3


### PR DESCRIPTION
Le rate limiting s'applique à `/` et à `/first_occurence/v1/` et est, par défaut, de 15 requetes / minute (ça se règle dans `config.py`)