### PR TITLE
Feat: [v1.1] ajout de `all_occurences`

### DIFF
--- a/app/dataset_parser.py
+++ b/app/dataset_parser.py
@@ -5,6 +5,7 @@ import re
 
 from config import DATASET_DATE_FORMAT
 
+
 class CGUsDataset():
     """
     Helper class for handling CGUs Versions
@@ -14,7 +15,6 @@ class CGUsDataset():
         self.root_path = Path(root_path)
         assert self.root_path.exists(), f"{root_path} does not exist"
         assert self.root_path.is_dir(), f"{root_path} is not a directory"
-
 
     def yield_all_md(self, ignore_rootdir: bool = True) -> list:
         if ignore_rootdir:
@@ -27,10 +27,11 @@ class CGUsParser(ABC):
     """
         Abstract base class for parsing a CGU dataset
     """
+
     def __init__(self, path: PosixPath):
         self.path = path
         self.dataset = CGUsDataset(self.path)
-    
+
     @abstractmethod
     def run(self):
         pass
@@ -38,51 +39,17 @@ class CGUsParser(ABC):
     @abstractmethod
     def to_dict(self):
         pass
-    
+
     @staticmethod
     def _parse_name(file_path):
         """
             Given a file path in the CGUs dataset,
             return the service, the document_type, and the version date
         """
-        version_date = datetime.strptime(file_path.name.rstrip(".md"), DATASET_DATE_FORMAT)
+        version_date = datetime.strptime(
+            file_path.name.rstrip(".md"), DATASET_DATE_FORMAT)
         service, document_type = file_path.as_posix().split("/")[-3:-1]
         return service, document_type, version_date
-
-
-
-class CGUsFirstOccurenceParser(CGUsParser):
-
-    def __init__(self, path, terms):
-        super().__init__(path)
-        self.regex_term = re.compile(rf"{self._to_regex(terms)}", re.IGNORECASE)
-    
-    def run(self):
-        """
-            For each service provider, and for each document type,
-            return date of first occurence of a given term (or comma-separated terms), or `False`
-        """
-        self.output = dict()
-
-        for md in self.dataset.yield_all_md(ignore_rootdir=True):
-            service, document_type, version_date = self._parse_name(md)
-            
-            # TODO: clean and optimize this
-            if service not in self.output.keys():
-                self.output[service] = {document_type: False}
-
-            if document_type not in self.output[service].keys():
-                self.output[service] = {**self.output[service], **{document_type: False}}
-
-            if self._file_contains(md):
-                if not self.output[service][document_type]:
-                    self.output[service][document_type] = version_date
-                elif version_date < self.output[service][document_type]:
-                    self.output[service][document_type] = version_date
-
-
-    def to_dict(self):
-        return self.output
 
     def _file_contains(self, file_path: Path):
         with open(file_path, "r") as f:
@@ -101,6 +68,36 @@ class CGUsFirstOccurenceParser(CGUsParser):
         return comma_separated_terms.replace(",", "|")
 
 
+class CGUsFirstOccurenceParser(CGUsParser):
 
+    def __init__(self, path, terms):
+        super().__init__(path)
+        self.regex_term = re.compile(
+            rf"{self._to_regex(terms)}", re.IGNORECASE)
 
+    def run(self):
+        """
+            For each service provider, and for each document type,
+            return date of first occurence of a given term (or comma-separated terms), or `False`
+        """
+        self.output = dict()
 
+        for md in self.dataset.yield_all_md(ignore_rootdir=True):
+            service, document_type, version_date = self._parse_name(md)
+
+            # TODO: clean and optimize this
+            if service not in self.output.keys():
+                self.output[service] = {document_type: False}
+
+            if document_type not in self.output[service].keys():
+                self.output[service] = {
+                    **self.output[service], **{document_type: False}}
+
+            if self._file_contains(md):
+                if not self.output[service][document_type]:
+                    self.output[service][document_type] = version_date
+                elif version_date < self.output[service][document_type]:
+                    self.output[service][document_type] = version_date
+
+    def to_dict(self):
+        return self.output

--- a/app/dataset_parser.py
+++ b/app/dataset_parser.py
@@ -101,3 +101,39 @@ class CGUsFirstOccurenceParser(CGUsParser):
 
     def to_dict(self):
         return self.output
+
+class CGUsAllOccurencesParser(CGUsParser):
+
+    def __init__(self, path, terms):
+        super().__init__(path)
+        self.regex_term = re.compile(
+            rf"{self._to_regex(terms)}", re.IGNORECASE)
+
+    def run(self):
+        """
+            For each service provider, and for each document type,
+            return date of first occurence of a given term (or comma-separated terms), or `False`
+        """
+        self.output = dict()
+
+        for md in self.dataset.yield_all_md(ignore_rootdir=True):
+            service, document_type, version_date = self._parse_name(md)
+
+
+            # TODO: clean and optimize this
+            if service not in self.output.keys():
+                self.output[service] = {
+                    document_type: {
+                        version_date: False
+                    }
+                }
+
+            if document_type not in self.output[service].keys():
+                self.output[service] = {
+                    **self.output[service], **{document_type: {version_date: False}}
+                }
+
+            self.output[service][document_type][version_date] = self._file_contains(md)
+
+    def to_dict(self):
+        return self.output

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 
 from config import CGUS_DATASET_PATH, RATE_LIMIT, BASE_PATH
-from dataset_parser import CGUsFirstOccurenceParser
+from dataset_parser import CGUsFirstOccurenceParser, CGUsAllOccurencesParser
 
 limiter = Limiter(key_func=get_remote_address)
 app = FastAPI(openapi_url=f"{BASE_PATH}/openapi.json",
@@ -26,5 +26,12 @@ async def index(request: Request):
 @limiter.limit(RATE_LIMIT)
 async def first_occurence(request: Request, term: str):
     parser = CGUsFirstOccurenceParser(Path(CGUS_DATASET_PATH), term)
+    parser.run()
+    return parser.to_dict()
+
+@app.get(f"{BASE_PATH}/all_occurences/v1/{{term}}")
+@limiter.limit(RATE_LIMIT)
+async def all_occurence(request: Request, term: str):
+    parser = CGUsAllOccurencesParser(Path(CGUS_DATASET_PATH), term)
     parser.run()
     return parser.to_dict()

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,8 @@ from config import CGUS_DATASET_PATH, RATE_LIMIT, BASE_PATH
 from dataset_parser import CGUsFirstOccurenceParser
 
 limiter = Limiter(key_func=get_remote_address)
-app = FastAPI(openapi_url=f"{BASE_PATH}/openapi.json", docs_url=f"{BASE_PATH}/docs")
+app = FastAPI(openapi_url=f"{BASE_PATH}/openapi.json",
+              docs_url=f"{BASE_PATH}/docs")
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
@@ -19,6 +20,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 @limiter.limit(RATE_LIMIT)
 async def index(request: Request):
     return RedirectResponse(f"{BASE_PATH}/docs")
+
 
 @app.get(f"{BASE_PATH}/first_occurence/v1/{{term}}")
 @limiter.limit(RATE_LIMIT)

--- a/tests/unit/test_dataset_parser.py
+++ b/tests/unit/test_dataset_parser.py
@@ -5,9 +5,10 @@ sys.path.append("./app/")
 
 import pytest
 
-from app.dataset_parser import CGUsDataset, CGUsFirstOccurenceParser
+from app.dataset_parser import CGUsDataset, CGUsFirstOccurenceParser, CGUsAllOccurencesParser
 
 # test CGUsDataset
+
 
 def test_path_check_ok():
     cgudataset = CGUsDataset(root_path="tests/test_dataset/")
@@ -56,3 +57,38 @@ def test_run_not_found():
     parser.run()
     output = parser.to_dict()
     assert output["FakeService"]["Community Guidelines"] == False
+
+
+# test CGUsAllOccurencesParser
+
+
+def test_run_california_all():
+    parser = CGUsAllOccurencesParser(Path("tests/test_dataset"), "California")
+    parser.run()
+    output = parser.to_dict()
+    assert set(output.keys()) == {"FakeService"}
+    assert set(output["FakeService"].keys()) == {"Community Guidelines"}
+    print(output["FakeService"]["Community Guidelines"])
+    assert output["FakeService"]["Community Guidelines"][datetime(
+        2020, 11, 9, 17, 30, 22)] == True
+    assert output["FakeService"]["Community Guidelines"][datetime(
+        2020, 11, 11, 16, 30, 22)] == True
+
+def test_run_rgpd_all():
+    parser = CGUsAllOccurencesParser(Path("tests/test_dataset"), "rgpd")
+    parser.run()
+    output = parser.to_dict()
+    assert output["FakeService"]["Community Guidelines"][datetime(
+        2020, 11, 9, 17, 30, 22)] == False
+    assert output["FakeService"]["Community Guidelines"][datetime(
+        2020, 11, 11, 16, 30, 22)] == True
+
+
+def test_run_not_found_all():
+    parser = CGUsAllOccurencesParser(Path("tests/test_dataset"), "Ambanum")
+    parser.run()
+    output = parser.to_dict()
+    assert output["FakeService"]["Community Guidelines"][datetime(
+        2020, 11, 9, 17, 30, 22)] == False
+    assert output["FakeService"]["Community Guidelines"][datetime(
+        2020, 11, 11, 16, 30, 22)] == False

--- a/tests/unit/test_dataset_parser.py
+++ b/tests/unit/test_dataset_parser.py
@@ -8,17 +8,22 @@ import pytest
 from app.dataset_parser import CGUsDataset, CGUsFirstOccurenceParser
 
 # test CGUsDataset
+
 def test_path_check_ok():
     cgudataset = CGUsDataset(root_path="tests/test_dataset/")
     assert cgudataset
 
+
 def test_path_check_not_a_directory():
-    with pytest.raises(AssertionError, match = "is not a directory"):
-        cgudataset = CGUsDataset(root_path="tests/test_dataset/FakeService/Community Guidelines/2020-11-09--17-30-22.md")
+    with pytest.raises(AssertionError, match="is not a directory"):
+        cgudataset = CGUsDataset(
+            root_path="tests/test_dataset/FakeService/Community Guidelines/2020-11-09--17-30-22.md")
+
 
 def test_path_check_directory_doesnt_exist():
-    with pytest.raises(AssertionError, match = "does not exist"):
+    with pytest.raises(AssertionError, match="does not exist"):
         cgudataset = CGUsDataset(root_path="tests/wrong_dir/")
+
 
 def test_list_files():
     cgudataset = CGUsDataset(root_path="tests/test_dataset/")
@@ -26,19 +31,25 @@ def test_list_files():
     assert len(list(cgudataset.yield_all_md(ignore_rootdir=False))) == 3
 
 # test CGUsFirstOccurenceParser
+
+
 def test_run_california():
     parser = CGUsFirstOccurenceParser(Path("tests/test_dataset"), "California")
     parser.run()
     output = parser.to_dict()
     assert set(output.keys()) == {"FakeService"}
     assert set(output["FakeService"].keys()) == {"Community Guidelines"}
-    assert output["FakeService"]["Community Guidelines"] == datetime(2020, 11, 9, 17, 30, 22)
+    assert output["FakeService"]["Community Guidelines"] == datetime(
+        2020, 11, 9, 17, 30, 22)
+
 
 def test_run_rgpd():
     parser = CGUsFirstOccurenceParser(Path("tests/test_dataset"), "rgpd")
     parser.run()
     output = parser.to_dict()
-    assert output["FakeService"]["Community Guidelines"] == datetime(2020, 11, 11, 16, 30, 22)
+    assert output["FakeService"]["Community Guidelines"] == datetime(
+        2020, 11, 11, 16, 30, 22)
+
 
 def test_run_not_found():
     parser = CGUsFirstOccurenceParser(Path("tests/test_dataset"), "Ambanum")


### PR DESCRIPTION
Le endpoint `all_occurences` renvoie, pour un terme donné : 

```
{
    service: {
        document_type: {
            date_1: True,
            date_2: False,
            date_3: True
        }
    }
}
```

ce qui reproduit la structure du dataset

Elle prend un peu plus de temps à tourner que l'autre endpoint (ce qui est logique).

WDYT ?