### PR TITLE
Preprod environment

### DIFF
--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -1,0 +1,23 @@
+name: Deploy
+on:
+  push:
+    branches: [develop]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: git checkout HEAD
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+      - run: echo "${{ secrets.ANSIBLE_VAULT_PASSWORD }}" > vault.key
+      - run: pip install --upgrade setuptools
+      - run: pip install ansible==2.9.11
+      - run: ansible-galaxy collection install community.general:==1.3.5
+      - run: ansible-playbook ops/site.yml -i ops/inventories/production.yml -e "api_env=preproduction"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,13 +1,12 @@
 name: Deploy
-
 on:
   push:
     branches: [main]
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
-
+    env:
+      CGUS_API_ENV: production
     steps:
       - uses: actions/checkout@v2
         with:
@@ -23,4 +22,4 @@ jobs:
       - run: pip install --upgrade setuptools
       - run: pip install ansible==2.9.11
       - run: ansible-galaxy collection install community.general:==1.3.5
-      - run: ansible-playbook ops/site.yml -i ops/inventories/production.yml
+      - run: ansible-playbook ops/site.yml -i ops/inventories/production.yml -e "api_env=production"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,19 +1,26 @@
 name: Test
-on: [push]
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+      - develop
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest
-        pip install -r requirements.txt
-    - name: Test with pytest
-      run: |
-        python -m pytest
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run pylint
+        run: |
+          python -m pylint --rcfile=./.pylintrc ./**/*.py
+      - name: Test with pytest
+        run: |
+          python -m pytest

--- a/app/config.py
+++ b/app/config.py
@@ -5,4 +5,9 @@ DATASET_DATE_FORMAT = "%Y-%m-%d--%H-%M-%S"
 RATE_LIMIT = "10000/minute"
 
 CGUS_API_ENV = os.getenv("CGUS_API_ENV", "development")
-BASE_PATH = "/api/open-terms-archive" if CGUS_API_ENV == "production" else ""
+ENV_MAPPING = {
+    "production": "/api/open-terms-archive",
+    "preproduction": "/api/open-terms-archive-preprod",
+    "development": "",
+}
+BASE_PATH = ENV_MAPPING.get("CGUS_API_ENV", "")

--- a/ops/roles/ota-api/tasks/main.yml
+++ b/ops/roles/ota-api/tasks/main.yml
@@ -14,17 +14,17 @@
   community.general.docker_image:
     source: build
     build:
-      path: "/home/{{ ansible_user }}/{{ app }}"
-    name: "{{ app }}"
+      path: "/home/{{ ansible_user }}/{{ app }}{{ api_env }}"
+    name: "{{ app }}{{ api_env }}"
     force_source: yes
 
 - name: Start the container
   become: yes
   community.general.docker_container:
-    name: "{{ app }}"
-    image: "{{ app }}"
+    name: "{{ app }}{{ api_env }}"
+    image: "{{ app }}{{ api_env }}"
     restart: yes
     ports:
-    - "{{ app_port }}:80"
+      - "{{ app_port }}:80"
     env:
-      CGUS_API_ENV: "production"
+      CGUS_API_ENV: "{{ api_env }}"


### PR DESCRIPTION
As agreed this morning, this PR would do the following thing :
- every push on `develop` would deploy the app at `51.75.169.235/api/open-terms-archive-preprod`
- every push on `main` would deploy the app at `51.75.169.235/api/open-terms-archive` which which NGINX redirects to production

So the preprod and prod apps would _both_ be deployed on the same machine. This is not very elegant and probably goes against most basic DevOps principles but we agreed that this could be a short-term solution that's relatively easy to implement.

WDYT ?