### PR TITLE
Feat/version api

### DIFF
--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -20,4 +20,4 @@ jobs:
       - run: pip install --upgrade setuptools
       - run: pip install ansible==2.9.11
       - run: ansible-galaxy collection install community.general:==1.3.5
-      - run: ansible-playbook ops/site.yml -i ops/inventories/production.yml -e "ENV=preproduction"
+      - run: ansible-playbook ops/site.yml -i ops/inventories/production.yml -e "ENV=preproduction GITHUB_SHA=$(GITHUB_SHA)"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -22,4 +22,4 @@ jobs:
       - run: pip install --upgrade setuptools
       - run: pip install ansible==2.9.11
       - run: ansible-galaxy collection install community.general:==1.3.5
-      - run: ansible-playbook ops/site.yml -i ops/inventories/production.yml -e "ENV=production"
+      - run: ansible-playbook ops/site.yml -i ops/inventories/production.yml -e "ENV=production GITHUB_SHA=$(GITHUB_SHA)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN chmod 0644 /etc/cron.d/check-for-data
 # DOWNLOAD DATASET
 COPY ./download_dataset.sh /download_dataset.sh
 RUN chmod +x /download_dataset.sh
-RUN /bin/bash -c "source /download_dataset.sh"
+RUN /download_dataset.sh
 
 # COPY AND RUN APP
 COPY ./app /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8-slim
+ARG COMMIT=""
+LABEL commit=${COMMIT}
+ENV COMMIT_SHA=${COMMIT}
 
 # INSTALL REQUIREMENTS
 COPY ./requirements.txt /requirements.txt

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,7 @@
 import os
 
 CGUS_DATASET_PATH = "./dataset/"
+LAST_DATASET_PATH = "./latest_dataset.txt"
 DATASET_DATE_FORMAT = "%Y-%m-%d--%H-%M-%S"
 RATE_LIMIT = "10000/minute"
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 # pylint: disable=unused-argument
 from pathlib import Path
+import os
 
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -40,6 +41,15 @@ async def index(request: Request):
     redirect index to documentation
     """
     return RedirectResponse(f"{BASE_PATH}/docs")
+
+
+async def dataset_version(request: Request):
+    """
+    Return the current dataset version used by the API
+    The list of dataset releases is available at
+     https://github.com/ambanum/OpenTermsArchive-versions/releases
+    """
+    return {"version": os.getenv("MOST_RECENT_DATASET", "unknown")}
 
 
 @app.get(f"{BASE_PATH}/first_occurence/v1/{{term}}")

--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,7 @@ from dataset_parser import (
     CGUsAllOccurencesParser,
     CGUsDataset,
 )
-from utils import parse_user_date
+from utils import parse_user_date, parse_date_from_dataset_url
 
 limiter = Limiter(key_func=get_remote_address)
 app = FastAPI(openapi_url=f"{BASE_PATH}/openapi.json", docs_url=f"{BASE_PATH}/docs")
@@ -99,8 +99,10 @@ async def version(request: Request):
      https://github.com/ambanum/OpenTermsArchive-versions/releases
     Also return the commit SHA on which the API was built
     """
+    dataset_url = read_dataset()
     return {
-        "dataset_version": read_dataset(),
+        "dataset_url": dataset_url,
+        "dataset_date": parse_date_from_dataset_url(dataset_url),
         "api_version": os.getenv("COMMIT_SHA", "unknown"),
     }
 

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 
-from config import CGUS_DATASET_PATH, RATE_LIMIT, BASE_PATH
+from config import CGUS_DATASET_PATH, RATE_LIMIT, BASE_PATH, LAST_DATASET_PATH
 from data_finder import CGUsDataFinder
 from dataset_parser import (
     CGUsFirstOccurenceParser,
@@ -33,6 +33,14 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+def read_dataset():
+    """
+    Get the current dataset version stored in a file
+    """
+    dataset_file = Path(LAST_DATASET_PATH)
+    return dataset_file.read_text().strip("\n")
 
 
 @app.on_event("startup")
@@ -64,7 +72,7 @@ async def version(request: Request):
     Also return the commit SHA on which the API was built
     """
     return {
-        "dataset_version": os.getenv("MOST_RECENT_DATASET", "unknown"),
+        "dataset_version": read_dataset(),
         "api_version": os.getenv("COMMIT_SHA", "unknown"),
     }
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 import logging
 from pathlib import Path
 import os
+import subprocess
 
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -35,6 +36,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+logger = logging.getLogger("uvicorn.error")
+
 
 def read_dataset():
     """
@@ -49,7 +52,6 @@ async def startup_event():
     """
     Log current commit on startup.
     """
-    logger = logging.getLogger("uvicorn.error")
     logger.info(f"Built using commit {os.getenv('COMMIT_SHA', 'unknown')}")
     logger.info(f"Dataset version : {read_dataset()}")
 
@@ -75,7 +77,8 @@ async def check_for_dataset(request: Request):
     )
     newest_dataset = req.json()["assets"][0]["browser_download_url"]
     if newest_dataset != read_dataset():
-        # TODO: download dataset
+        process = subprocess.Popen(["/download_dataset.sh"])
+        logger.info(f"Downloading new dataset. Process pid: {process.pid}")
         return {
             "status": "a new dataset is available. downloading.",
             "most_recent_dataset": f"{newest_dataset}",

--- a/app/main.py
+++ b/app/main.py
@@ -50,7 +50,7 @@ async def startup_event():
     """
     logger = logging.getLogger("uvicorn.error")
     logger.info(f"Built using commit {os.getenv('COMMIT_SHA', 'unknown')}")
-    logger.info(f"Dataset version : {os.getenv('MOST_RECENT_DATASET', 'unknown')}")
+    logger.info(f"Dataset version : {read_dataset()}")
 
 
 @app.get(f"{BASE_PATH}/")

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import re
 
 
 def parse_user_date(user_date: str):
@@ -10,3 +11,16 @@ def parse_user_date(user_date: str):
         hour=23, minute=59, second=59, microsecond=59
     )
     return parsed_datetime
+
+
+def parse_date_from_dataset_url(url: str):
+    """
+    Given a dataset release url,
+    Parse and return its date
+    """
+    date_regex = re.compile("([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))")
+    dataset = url.split("/")[-1]
+    date = date_regex.search(dataset)
+    if date:
+        return date.group()
+    return "could not parse"

--- a/download_dataset.sh
+++ b/download_dataset.sh
@@ -2,4 +2,4 @@
 file_url=$(curl --silent "https://api.github.com/repos/ambanum/OpenTermsArchive-versions/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/')
 curl -LJS $file_url -o dataset.zip
 unzip -o dataset.zip && rm -rf dataset && mv dataset-* dataset
-export MOST_RECENT_DATASET=$file_url
+echo $file_url > latest_dataset.txt

--- a/ops/roles/ota-api/github-clone/tasks/main.yml
+++ b/ops/roles/ota-api/github-clone/tasks/main.yml
@@ -18,6 +18,8 @@
   community.general.docker_image:
     source: build
     build:
+      args:
+        COMMIT: "{{ GITHUB_SHA }}"
       path: "/home/{{ ansible_user }}/{{ app }}"
     name: "{{ app }}"
     force_source: yes

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,10 +3,13 @@ astroid==2.5
 attrs==20.3.0
 autopep8==1.5.4
 black==20.8b1
+certifi==2020.12.5
+chardet==4.0.0
 click==7.1.2
 configparser==5.0.1
 fastapi==0.61.2
 h11==0.11.0
+idna==2.10
 iniconfig==1.1.1
 isort==5.7.0
 lazy-object-proxy==1.5.2
@@ -25,11 +28,13 @@ pytest==6.1.2
 python-githooks==1.0.6
 redis==3.5.3
 regex==2020.11.13
+requests==2.25.1
 six==1.15.0
 slowapi==0.1.2
 starlette==0.13.6
 toml==0.10.2
 typed-ast==1.4.2
 typing-extensions==3.7.4.3
+urllib3==1.26.3
 uvicorn==0.12.3
 wrapt==1.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click==7.1.2
 fastapi==0.61.2
 h11==0.11.0
 pydantic==1.7.2
+requests==2.25.1
 slowapi==0.1.2
 starlette==0.13.6
 uvicorn==0.12.3

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,7 +6,7 @@ sys.path.append("./app/")
 
 import pytest
 
-from app.utils import parse_user_date
+from app.utils import parse_user_date, parse_date_from_dataset_url
 
 
 def test_parse_date():
@@ -28,3 +28,21 @@ def test_parse_date_comparison():
     assert date >= datetime(2020, 10, 31, 9, 59, 59, 59)
     assert date >= datetime(2020, 10, 31, 23, 59, 59, 59)
     assert date < datetime(2020, 11, 1, 0, 0, 0, 0)
+
+
+def test_parse_date_from_url():
+    url = "https://github.com/releases/download/2021-03-04-fff81e8/dataset-2021-03-04-fff81e8.zip"
+    parsed = parse_date_from_dataset_url(url)
+    assert parsed == "2021-03-04"
+
+
+def test_parse_date_from_url_no_date():
+    url = "https://google.com"
+    parsed = parse_date_from_dataset_url(url)
+    assert parsed == "could not parse"
+
+
+def test_parse_date_from_url_wrong_date_format():
+    url = "https://github.com/releases/download/2021-03-04-fff81e8/dataset-04-03-2021-fff81e8.zip"
+    parsed = parse_date_from_dataset_url(url)
+    assert parsed == "could not parse"


### PR DESCRIPTION
This PR: 
- allows the API to log the commit and dataset id it was built on
- these infos are also available directly from the `/version` route of the API

Right now, this work by building the docker with the following command :
`docker build --build-arg=COMMIT=$(git rev-parse --short HEAD) --tag cgus-api:latest .`

But I am not sure if this command will work in ansible.

What do you think ?